### PR TITLE
Hecho controlador con documentación open API de evidencia con sus res…

### DIFF
--- a/backend/src/main/java/com/leoalelui/ticketsystem/domain/dto/request/EvidenceCreateDTO.java
+++ b/backend/src/main/java/com/leoalelui/ticketsystem/domain/dto/request/EvidenceCreateDTO.java
@@ -1,0 +1,22 @@
+package com.leoalelui.ticketsystem.domain.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@Schema(description = "DTO para crear nueva evidencia.")
+public class EvidenceCreateDTO {
+
+    @Schema(description = "ID del ticket que se creara la evidencia", example = "1")
+    @NotNull(message = "La ID del ticket es obligatoria")
+    private Long ticketId;
+
+    @Schema(description = "URL de la imagen de evidencia", example = "https://example.com/evidence1.png")
+    @NotBlank(message = "La URL de evidencia no puede estar vacia")
+    private String url;
+
+}

--- a/backend/src/main/java/com/leoalelui/ticketsystem/domain/dto/response/EvidenceResponseDTO.java
+++ b/backend/src/main/java/com/leoalelui/ticketsystem/domain/dto/response/EvidenceResponseDTO.java
@@ -1,0 +1,20 @@
+package com.leoalelui.ticketsystem.domain.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@Schema(description = "DTO para devolver la información de la evidencia")
+public class EvidenceResponseDTO {
+
+    @Schema(description = "ID de la evidencia", example = "10")
+    private Long id;
+
+    @Schema(description = "ID del ticket asociado a la evidencia", example = "1")
+    private Long ticketId;
+
+    @Schema(description = "URL de la imagen de evidencia", example = "https://example.com/evidence1.png")
+    private String url;
+}

--- a/backend/src/main/java/com/leoalelui/ticketsystem/persistence/entity/EvidenceEntity.java
+++ b/backend/src/main/java/com/leoalelui/ticketsystem/persistence/entity/EvidenceEntity.java
@@ -1,0 +1,26 @@
+package com.leoalelui.ticketsystem.persistence.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+/**
+ * @Author: alej0nt
+ */
+
+@Data
+@Entity
+@Table (name = "evidence")
+public class EvidenceEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private long id;
+
+    @ManyToOne
+    @JoinColumn (name = "ticket_id", nullable = false)
+    private TicketEntity ticket;
+
+    private String url;
+
+}

--- a/backend/src/main/java/com/leoalelui/ticketsystem/presentation/controller/EvidenceController.java
+++ b/backend/src/main/java/com/leoalelui/ticketsystem/presentation/controller/EvidenceController.java
@@ -1,0 +1,78 @@
+package com.leoalelui.ticketsystem.presentation.controller;
+
+import com.leoalelui.ticketsystem.domain.dto.request.EvidenceCreateDTO;
+import com.leoalelui.ticketsystem.domain.dto.response.EvidenceResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("api/v1/evidencias")
+@Tag(name = "Evidencias", description = "API para la gestión de evidencias (imágenes) asociadas a los tickets.")
+public class EvidenceController {
+
+    @Operation(summary = "Obtener todas las evidencias de un ticket",
+            description = "Devuelve una lista con todas las evidencias asociadas a un ticket específico.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Se devuelve la lista de evidencias exitosamente."),
+            @ApiResponse(responseCode = "204", description = "El ticket no tiene evidencias registradas."),
+            @ApiResponse(responseCode = "401", description = "Token inválido o ausente.")
+    })
+    @GetMapping("/ticket/{ticketId}")
+    public ResponseEntity<List<EvidenceResponseDTO>> getAllByTicket(
+            @Parameter(description = "ID del ticket") @PathVariable Long ticketId,
+            @RequestHeader("Authorization") String token) {
+        return ResponseEntity.ok(null);
+    }
+
+    @Operation(summary = "Obtener una evidencia por su ID",
+            description = "Devuelve la información de una evidencia específica mediante su ID.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Se devuelve la evidencia correctamente."),
+            @ApiResponse(responseCode = "404", description = "No se encontró la evidencia con el ID especificado."),
+            @ApiResponse(responseCode = "401", description = "Token inválido o ausente.")
+    })
+    @GetMapping("/{id}")
+    public ResponseEntity<EvidenceResponseDTO> getById(
+            @Parameter(description = "ID de la evidencia") @PathVariable Long id,
+            @RequestHeader("Authorization") String token) {
+        return ResponseEntity.ok(null);
+    }
+
+    @Operation(summary = "Crear una nueva evidencia",
+            description = "Crea una nueva evidencia (imagen) y la asocia a un ticket existente.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "La evidencia fue creada exitosamente."),
+            @ApiResponse(responseCode = "400", description = "Datos de la solicitud inválidos."),
+            @ApiResponse(responseCode = "401", description = "Token inválido o ausente.")
+    })
+    @PostMapping
+    public ResponseEntity<EvidenceResponseDTO> create(
+            @Valid @RequestBody EvidenceCreateDTO evidenceCreateDTO,
+            @RequestHeader("Authorization") String token) {
+        return ResponseEntity.status(201).body(null);
+    }
+
+    @Operation(summary = "Eliminar una evidencia",
+            description = "Elimina una evidencia específica mediante su ID.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "La evidencia fue eliminada correctamente."),
+            @ApiResponse(responseCode = "404", description = "No se encontró la evidencia con el ID especificado."),
+            @ApiResponse(responseCode = "401", description = "Token inválido o ausente.")
+    })
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(
+            @Parameter(description = "ID de la evidencia") @PathVariable Long id,
+            @RequestHeader("Authorization") String token) {
+        return ResponseEntity.noContent().build();
+    }
+}


### PR DESCRIPTION
### Lo que realicé:
- Creación del controlador `EvidenceController` con los siguientes **endpoints** documentados en OpenAPI:
  - `GET /api/v1/evidencias/ticket/{ticketId}` → Obtener todas las evidencias asociadas a un ticket.  
  - `GET /api/v1/evidencias/{id}` → Obtener una evidencia específica por su ID.  
  - `POST /api/v1/evidencias` → Crear una nueva evidencia y asociarla a un ticket.  
  - `DELETE /api/v1/evidencias/{id}` → Eliminar una evidencia existente.  
- Definición de **DTOs especializados**:
  - `EvidenceCreateDTO` → Para la creación de evidencias.  
  - `EvidenceResponseDTO` → Para devolver información estructurada en las respuestas.  
- Incorporación de **documentación con OpenAPI** para todos los endpoints:  
  - **Resumen y descripción** de cada operación.  
  - **Respuestas documentadas** (200, 201, 204, 400, 401, 404).  